### PR TITLE
Add a clang-include-input-paths option

### DIFF
--- a/src/config_json.cpp
+++ b/src/config_json.cpp
@@ -285,6 +285,7 @@ void Config::load_Defaults()
    m_cfgString.insert("clang-compilation-path",  struc_CfgString { QString(),       DEFAULT } );
    m_cfgString.insert("clang-dialect",           struc_CfgString { "--std=c++14",   DEFAULT } );
    m_cfgBool.insert("clang-use-headers",         struc_CfgBool   { true,            DEFAULT } );
+   m_cfgBool.insert("clang-include-input-paths", struc_CfgBool   { true,            DEFAULT } );
    m_cfgList.insert("clang-flags",               struc_CfgList   { QStringList(),   DEFAULT } );
 
    // tab 2 - source listing

--- a/src/parse_clang.cpp
+++ b/src/parse_clang.cpp
@@ -514,13 +514,14 @@ static bool documentKind(CXCursor cursor)
 // ** entry point
 void ClangParser::start(const QString &fileName, const QString &fileBuffer, QStringList &includeFiles, QSharedPointer<Entry> root)
 {
-   static QStringList const includePath          = Config::getList("include-path");
-   static QStringList const preDefinedMacros     = Config::getList("predefined-macros");
+   static QStringList const includePath            = Config::getList("include-path");
+   static QStringList const preDefinedMacros       = Config::getList("predefined-macros");
 
-   static QString     const clangCompilationPath = Config::getString("clang-compilation-path");
-   static QString     const clangDialect         = Config::getString("clang-dialect");
-   static bool        const clangUseHeaders      = Config::getBool("clang-use-headers");
-   static QStringList const clangFlags           = Config::getList("clang-flags");
+   static QString     const clangCompilationPath   = Config::getString("clang-compilation-path");
+   static QString     const clangDialect           = Config::getString("clang-dialect");
+   static bool        const clangUseHeaders        = Config::getBool("clang-use-headers");
+   static bool        const clangIncludeInputPaths = Config::getBool("clang-include-input-paths");
+   static QStringList const clangFlags             = Config::getList("clang-flags");
 
    // static const Qt::CaseSensitivity allowUpperCaseNames_enum = Config::getCase("case-sensitive-fname");
 
@@ -625,8 +626,10 @@ void ClangParser::start(const QString &fileName, const QString &fileBuffer, QStr
          }
 
          // add include paths for input files
-         for (auto &item : Doxy_Globals::inputPaths) {
-            argList.push_back("-I" + item);
+         if (clangIncludeInputPaths) {
+            for (auto &item : Doxy_Globals::inputPaths) {
+               argList.push_back("-I" + item);
+            }
          }
 
          // add external include paths


### PR DESCRIPTION
This PR adds a new option, `clang-include-input-paths`, which is on by default. If this option is on, then the directory of each input file is added to the include path when using Clang parsing. This behavior is the current status quo, but some projects need to be able to disable it.

Adding the directory of every input file to the include path is problematic for a number of projects. We ran into problems with it in [Thrust](https://github.com/NVIDIA/thrust).

For example, imagine a project that has this structure:

```
include/myproject/version.h
include/myproject/component0/coolstuff.h
include/myproject/component1/coolstuff.h
include/myproject/component1/widget.h
```

And those files are intended to be included by users as:

```
#include <myproject/version.h>
#include <myproject/component0/coolstuff.h>
#include <myproject/component1/coolstuff.h>
#include <myproject/component1/widget.h>
```

But within `include/myproject/component1/widget.h`, you might have:

```
#include "coolstuff.h" // Should resolve to `include/myproject/component1/coolstuff.h`.
```

If you have `"input-source" = [ "include/" ]`, then the directories of all headers found in `include` will be added as includes by Doxypress:

```
-Iinclude/myproject -Iinclude/myproject/component0 -Iinclude/myproject/component1
```

This is problematic, because now `include/myproject/component1/widget.h` will include `include/myproject/component0/coolstuff.h` instead of `include/myproject/component1/coolstuff.h`.

Alternatively, consider the case we ran into in Thrust, where our project structure looks like:

```
thrust/version.h
...
thrust/system/detail/errno.h
...
```

With `"input-source" = [ "thrust" ]`, Doxypress will add the following as includes:

```
"-Ithrust ... -Ithrust/system/detail"
```

This is problematic because `errno.h` is also the name of a system header, and will now be found instead of the system header.




