### PR TITLE
Added height/width and svg format to dia file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ error.log
 /do-*
 /build/
 /deploy/
+clang_lib/

--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -27,7 +27,7 @@
 
 static const int maxCmdLine = 40960;
 
-void writeDiaGraphFromFile(const QString &inFile, const QString &outDir, const QString &outFile, DiaOutputFormat format)
+void writeDiaGraphFromFile(const QString &inFile, const QString &outDir, const QString &outFile, DiaOutputFormat format, const QString width, const QString heigth)
 {
    static const QString diaPath = Config::getString("dia-path");
 
@@ -44,13 +44,25 @@ void writeDiaGraphFromFile(const QString &inFile, const QString &outDir, const Q
 
    diaArgs += "-n ";
 
-   if (format == DIA_BITMAP) {
-      diaArgs += "-t png-libart";
-      extension = ".png";
-
-   } else if (format == DIA_EPS) {
-      diaArgs += "-t eps";
-      extension = ".eps";
+   switch(format) {
+      case DIA_BITMAP:
+         diaArgs += "-t png-libart";
+         extension = ".png";
+         // png is the only format that suports heigth and width
+         if(!width.isEmpty() || !heigth.isEmpty()) {
+            diaArgs += " -s "+width+"x"+heigth;
+         }
+         break;
+      case DIA_EPS:
+         diaArgs += "-t eps";
+         extension = ".eps";
+         break;
+      case DIA_SVG:
+         diaArgs += "-t svg";
+         extension = ".svg";
+         break;
+      default:
+		 break;
    }
 
    diaArgs += " -e \"";

--- a/src/dia.h
+++ b/src/dia.h
@@ -21,9 +21,9 @@
 
 class QByteArray;
 
-enum DiaOutputFormat { DIA_BITMAP , DIA_EPS };
+enum DiaOutputFormat { DIA_BITMAP , DIA_EPS ,DIA_SVG};
 
-void writeDiaGraphFromFile(const QString &inFile, const QString &outDir, const QString &outFile, DiaOutputFormat format);
+void writeDiaGraphFromFile(const QString &inFile, const QString &outDir, const QString &outFile, DiaOutputFormat format, const QString width="" , const QString heigth="");
 
 #endif
 

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2215,7 +2215,7 @@ void HtmlDocVisitor::visitPre(DocDiaFile *df)
    }
 
    m_t << "<div class=\"diagraph\">" << endl;
-   writeDiaFile(df->file(), df->relPath(), df->context());
+   writeDiaFile(df);
 
    if (df->hasCaption()) {
       m_t << "<div class=\"caption\">" << endl;
@@ -2797,11 +2797,15 @@ void HtmlDocVisitor::writeMscFile(const QString &fileName, const QString &relPat
    writeMscImageMapFromFile(m_t, fileName, htmlOutput, relPath, baseName, context, mscFormat);
 }
 
-void HtmlDocVisitor::writeDiaFile(const QString &fileName, const QString &relPath, const QString &)
+void HtmlDocVisitor::writeDiaFile(DocDiaFile * df)
 {
    static const QString htmlOutput  = Config::getString("html-output");
+   QString imageExt   = Config::getEnum("dot-image-extension");
 
-   QString baseName = fileName;
+   QString baseName = df->file();
+   QString relPath = df->context();
+   QString htmlArgs;
+
    int i;
 
    if ((i = baseName.lastIndexOf('/')) != -1) {
@@ -2816,9 +2820,21 @@ void HtmlDocVisitor::writeDiaFile(const QString &fileName, const QString &relPat
 
    baseName.prepend("dia_");
 
-   writeDiaGraphFromFile(fileName, htmlOutput, baseName, DIA_BITMAP);
+   if (imageExt == "svg") {
+      writeDiaGraphFromFile(df->file(), htmlOutput, baseName, DIA_SVG);
+   } else {
+      writeDiaGraphFromFile(df->file(), htmlOutput, baseName, DIA_BITMAP,df->width(),df->height());
+      imageExt="png";
 
-   m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />" << endl;
+   }
+      if(!df->width().isEmpty()){
+         htmlArgs+=" width=\""+df->width()+"\" ";
+      }
+      if(!df->height().isEmpty()){
+         htmlArgs+=" height=\""+df->height()+"\" ";
+      }
+
+   m_t << "<img src=\"" << relPath << baseName << "." << imageExt << "\""<< htmlArgs << "/>" << endl;
 }
 
 void HtmlDocVisitor::writePlantUMLFile(const QString &fileName, const QString &relPath, const QString &)

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -143,7 +143,7 @@ class HtmlDocVisitor : public DocVisitor
 
    void writeDotFile(const QString &fileName, const QString &relPath, const QString &context);
    void writeMscFile(const QString &fileName, const QString &relPath, const QString &context);
-   void writeDiaFile(const QString &fileName, const QString &relPath, const QString &context);
+   void writeDiaFile(DocDiaFile *);
    void writePlantUMLFile(const QString &fileName, const QString &relPath, const QString &context);
 
    void pushEnabled();


### PR DESCRIPTION
Only added for the html output
if dot-image-format is set to svg
\diafile will output dia files as svg

also if width / heigth is added to \diafile
the generared image html tag fill have width= height= added and if the dot-image-format is png width and height argument is added to the call to dia.